### PR TITLE
feat: respond to pointer movement

### DIFF
--- a/src/hooks/usePointerControls.js
+++ b/src/hooks/usePointerControls.js
@@ -8,9 +8,25 @@ export function usePointerControls(callback) {
       callback({ type: 'down', x, y, pointerType });
     };
 
+    const handlePointerMove = (event) => {
+      event.preventDefault();
+      const { clientX: x, clientY: y, pointerType } = event;
+      callback({ type: 'move', x, y, pointerType });
+    };
+
+    const handlePointerUp = (event) => {
+      event.preventDefault();
+      const { clientX: x, clientY: y, pointerType } = event;
+      callback({ type: 'up', x, y, pointerType });
+    };
+
     window.addEventListener('pointerdown', handlePointerDown);
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', handlePointerUp);
     return () => {
       window.removeEventListener('pointerdown', handlePointerDown);
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', handlePointerUp);
     };
   }, [callback]);
 }

--- a/src/pages/GameScreen.js
+++ b/src/pages/GameScreen.js
@@ -60,15 +60,29 @@ function GameScreen() {
     return () => cancelAnimationFrame(animationId);
   }, [dispatch]);
 
-  usePointerControls(({ x, y, pointerType }) => {
-    console.log(`Pointer down at ${x}, ${y} via ${pointerType}`);
-    stateRef.current.bullets.push({
-      x: stateRef.current.player.x + stateRef.current.player.width / 2 - 4,
-      y: stateRef.current.player.y,
-      width: 8,
-      height: 16,
-      vy: 6,
-    });
+  usePointerControls(({ type, x, y }) => {
+    if (type === 'move' || type === 'down') {
+      const player = stateRef.current.player;
+      player.x = Math.max(
+        0,
+        Math.min(800 - player.width, x - player.width / 2)
+      );
+      player.y = Math.max(
+        0,
+        Math.min(600 - player.height, y - player.height / 2)
+      );
+    } else if (type === 'up') {
+      stateRef.current.bullets.push({
+        x:
+          stateRef.current.player.x +
+          stateRef.current.player.width / 2 -
+          4,
+        y: stateRef.current.player.y,
+        width: 8,
+        height: 16,
+        vy: 6,
+      });
+    }
   });
 
   return (


### PR DESCRIPTION
## Summary
- capture pointer movement and pointer-up events via new usePointerControls handlers
- move player with pointer motion and fire bullets on pointer release

## Testing
- `npm test -- --watchAll=false 2>&1 | cat -n`


------
https://chatgpt.com/codex/tasks/task_e_688ec8d98c64832a9c2c9f89811932c0