### PR TITLE
Add bullet-enemy collisions with scoring and effects

### DIFF
--- a/src/pages/GameScreen.js
+++ b/src/pages/GameScreen.js
@@ -21,7 +21,7 @@ function GameScreen() {
     loadSprites().then((sprites) => {
       const render = () => {
         ctx.clearRect(0, 0, canvas.width, canvas.height);
-        updateGameState(state);
+        updateGameState(state, dispatch);
 
         ctx.drawImage(
           sprites.player || sprites.enemies,
@@ -48,6 +48,16 @@ function GameScreen() {
             bullet.y,
             bullet.width,
             bullet.height
+          );
+        });
+
+        state.explosions.forEach((explosion) => {
+          ctx.drawImage(
+            sprites.explosion,
+            explosion.x,
+            explosion.y,
+            explosion.width,
+            explosion.height
           );
         });
 

--- a/src/utils/gameState.js
+++ b/src/utils/gameState.js
@@ -1,3 +1,5 @@
+import { incrementScore } from '../store/gameSlice';
+
 export function createGameState() {
   return {
     player: { x: 400, y: 550, width: 48, height: 48, vx: 0, vy: 0 },
@@ -6,10 +8,11 @@ export function createGameState() {
       { x: 300, y: 50, width: 48, height: 48, vx: -1, vy: 0 },
     ],
     bullets: [],
+    explosions: [],
   };
 }
 
-export function updateGameState(state) {
+export function updateGameState(state, dispatch) {
   state.enemies.forEach((enemy) => {
     enemy.x += enemy.vx;
     enemy.y += enemy.vy;
@@ -22,4 +25,35 @@ export function updateGameState(state) {
     bullet.y -= bullet.vy;
   });
   state.bullets = state.bullets.filter((bullet) => bullet.y + bullet.height > 0);
+
+  for (let i = state.bullets.length - 1; i >= 0; i--) {
+    const bullet = state.bullets[i];
+    for (let j = state.enemies.length - 1; j >= 0; j--) {
+      const enemy = state.enemies[j];
+      const overlap =
+        bullet.x < enemy.x + enemy.width &&
+        bullet.x + bullet.width > enemy.x &&
+        bullet.y < enemy.y + enemy.height &&
+        bullet.y + bullet.height > enemy.y;
+
+      if (overlap) {
+        state.bullets.splice(i, 1);
+        state.enemies.splice(j, 1);
+        state.explosions.push({
+          x: enemy.x,
+          y: enemy.y,
+          width: enemy.width,
+          height: enemy.height,
+          frame: 0,
+        });
+        dispatch && dispatch(incrementScore());
+        break;
+      }
+    }
+  }
+
+  state.explosions.forEach((explosion) => {
+    explosion.frame += 1;
+  });
+  state.explosions = state.explosions.filter((explosion) => explosion.frame < 15);
 }

--- a/src/utils/gameState.test.js
+++ b/src/utils/gameState.test.js
@@ -3,8 +3,19 @@ import { createGameState, updateGameState } from './gameState';
 test('updateGameState moves enemies and bullets', () => {
   const state = createGameState();
   state.enemies = [{ x: 0, y: 0, width: 10, height: 10, vx: 1, vy: 0 }];
-  state.bullets = [{ x: 0, y: 10, width: 5, height: 5, vy: 2 }];
-  updateGameState(state);
+  state.bullets = [{ x: 0, y: 20, width: 5, height: 5, vy: 2 }];
+  updateGameState(state, () => {});
   expect(state.enemies[0].x).toBe(1);
-  expect(state.bullets[0].y).toBe(8);
+  expect(state.bullets[0].y).toBe(18);
+});
+
+test('bullet and enemy collision removes both and increments score', () => {
+  const state = createGameState();
+  state.enemies = [{ x: 0, y: 0, width: 10, height: 10, vx: 0, vy: 0 }];
+  state.bullets = [{ x: 0, y: 0, width: 10, height: 10, vy: 0 }];
+  const dispatch = jest.fn();
+  updateGameState(state, dispatch);
+  expect(state.enemies).toHaveLength(0);
+  expect(state.bullets).toHaveLength(0);
+  expect(dispatch).toHaveBeenCalled();
 });


### PR DESCRIPTION
## Summary
- detect bullet-enemy overlaps in the game state, award score, and spawn explosions
- render explosion sprites on GameScreen
- test bullet-enemy collision logic and score dispatch

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_688ee2695a58832aaad0710683ce4fcf