### PR TITLE
Add difficulty-based enemy spawns

### DIFF
--- a/src/store/settingsSlice.js
+++ b/src/store/settingsSlice.js
@@ -1,5 +1,14 @@
 import { createSlice } from '@reduxjs/toolkit';
 
+// Configuration for each difficulty level. This centralizes the enemy
+// behaviour so game logic can adjust spawn timing and speed according to the
+// player's preference.
+export const DIFFICULTY_CONFIG = {
+  easy: { enemySpeed: 1, spawnInterval: 120 },
+  normal: { enemySpeed: 2, spawnInterval: 80 },
+  hard: { enemySpeed: 3, spawnInterval: 40 },
+};
+
 const initialState = {
   soundOn: true,
   difficulty: 'normal',


### PR DESCRIPTION
## Summary
- configure enemy speed and spawn rates per difficulty level
- spawn enemies on a timer that reacts to current difficulty and levels
- adjust spawn interval when difficulty changes during play

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ee36e2658832aadee16ca65dcac2a