### PR TITLE
Use delta time for consistent motion

### DIFF
--- a/src/pages/GameScreen.js
+++ b/src/pages/GameScreen.js
@@ -17,11 +17,15 @@ function GameScreen() {
     const ctx = canvas.getContext('2d');
     const state = (stateRef.current = createGameState());
     let animationId;
+    let lastTime = performance.now();
 
     loadSprites().then((sprites) => {
-      const render = () => {
+      const render = (time) => {
+        const delta = (time - lastTime) / 1000;
+        lastTime = time;
+
         ctx.clearRect(0, 0, canvas.width, canvas.height);
-        updateGameState(state, dispatch);
+        updateGameState(state, dispatch, delta);
 
         ctx.drawImage(
           sprites.player || sprites.enemies,
@@ -64,7 +68,7 @@ function GameScreen() {
         animationId = requestAnimationFrame(render);
       };
 
-      render();
+      animationId = requestAnimationFrame(render);
     });
 
     return () => cancelAnimationFrame(animationId);

--- a/src/utils/gameState.js
+++ b/src/utils/gameState.js
@@ -44,8 +44,9 @@ export function createGameState() {
   };
 }
 
-export function updateGameState(state, dispatch) {
+export function updateGameState(state, dispatch, delta = 1 / 60) {
   const difficulty = store.getState().settings.difficulty;
+  const deltaFrames = delta * 60;
 
   // If difficulty changed mid-game, update spawn interval accordingly
   if (difficulty !== state.difficulty) {
@@ -55,22 +56,22 @@ export function updateGameState(state, dispatch) {
   }
 
   // Handle enemy spawning based on a timer
-  state.spawnTimer += 1;
+  state.spawnTimer += deltaFrames;
   if (state.spawnTimer >= state.spawnInterval) {
     state.enemies.push(createEnemy(difficulty));
     state.spawnTimer = 0;
   }
 
   state.enemies.forEach((enemy) => {
-    enemy.x += enemy.vx;
-    enemy.y += enemy.vy;
+    enemy.x += enemy.vx * deltaFrames;
+    enemy.y += enemy.vy * deltaFrames;
     if (enemy.x < 0 || enemy.x + enemy.width > 800) {
       enemy.vx *= -1;
     }
   });
 
   state.bullets.forEach((bullet) => {
-    bullet.y -= bullet.vy;
+    bullet.y -= bullet.vy * deltaFrames;
   });
   state.bullets = state.bullets.filter((bullet) => bullet.y + bullet.height > 0);
 
@@ -109,7 +110,7 @@ export function updateGameState(state, dispatch) {
   }
 
   state.explosions.forEach((explosion) => {
-    explosion.frame += 1;
+    explosion.frame += deltaFrames;
   });
   state.explosions = state.explosions.filter((explosion) => explosion.frame < 15);
 }

--- a/src/utils/gameState.test.js
+++ b/src/utils/gameState.test.js
@@ -4,7 +4,7 @@ test('updateGameState moves enemies and bullets', () => {
   const state = createGameState();
   state.enemies = [{ x: 0, y: 0, width: 10, height: 10, vx: 1, vy: 0 }];
   state.bullets = [{ x: 0, y: 20, width: 5, height: 5, vy: 2 }];
-  updateGameState(state, () => {});
+  updateGameState(state, () => {}, 1 / 60);
   expect(state.enemies[0].x).toBe(1);
   expect(state.bullets[0].y).toBe(18);
 });
@@ -14,7 +14,7 @@ test('bullet and enemy collision removes both and increments score', () => {
   state.enemies = [{ x: 0, y: 0, width: 10, height: 10, vx: 0, vy: 0 }];
   state.bullets = [{ x: 0, y: 0, width: 10, height: 10, vy: 0 }];
   const dispatch = jest.fn();
-  updateGameState(state, dispatch);
+  updateGameState(state, dispatch, 1 / 60);
   expect(state.enemies).toHaveLength(0);
   expect(state.bullets).toHaveLength(0);
   expect(dispatch).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- capture frame-to-frame elapsed time in `GameScreen` and forward it to the game state updater
- scale spawn timers, enemy movement, bullets, and explosions by delta time for frame-rate independent behavior
- adjust unit tests to use delta-time updates

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ee84af4e4832a80fa48e541e02998