### PR TITLE
feat: support multitouch and clamp player position

### DIFF
--- a/src/hooks/usePointerControls.js
+++ b/src/hooks/usePointerControls.js
@@ -2,31 +2,59 @@ import { useEffect } from 'react';
 
 export function usePointerControls(callback) {
   useEffect(() => {
+    let activePointerId = null;
+    let lastMove = 0;
+    const THROTTLE_MS = 16;
+
     const handlePointerDown = (event) => {
       event.preventDefault();
-      const { clientX: x, clientY: y, pointerType } = event;
-      callback({ type: 'down', x, y, pointerType });
+      const { pointerId, clientX: x, clientY: y, pointerType } = event;
+
+      if (activePointerId === null) {
+        activePointerId = pointerId;
+        callback({ type: 'down', x, y, pointerType });
+      } else {
+        // Secondary touches trigger a fire event
+        callback({ type: 'fire', x, y, pointerType });
+      }
     };
 
     const handlePointerMove = (event) => {
       event.preventDefault();
-      const { clientX: x, clientY: y, pointerType } = event;
+      const { pointerId, clientX: x, clientY: y, pointerType } = event;
+
+      if (pointerId !== activePointerId) return;
+
+      const now = performance.now();
+      if (now - lastMove < THROTTLE_MS) return;
+      lastMove = now;
+
       callback({ type: 'move', x, y, pointerType });
     };
 
     const handlePointerUp = (event) => {
       event.preventDefault();
-      const { clientX: x, clientY: y, pointerType } = event;
-      callback({ type: 'up', x, y, pointerType });
+      const { pointerId, clientX: x, clientY: y, pointerType } = event;
+
+      if (pointerId === activePointerId) {
+        activePointerId = null;
+        callback({ type: 'up', x, y, pointerType });
+      } else {
+        // Treat pointer releases from other touches as fire events
+        callback({ type: 'fire', x, y, pointerType });
+      }
     };
 
-    window.addEventListener('pointerdown', handlePointerDown);
-    window.addEventListener('pointermove', handlePointerMove);
-    window.addEventListener('pointerup', handlePointerUp);
+    window.addEventListener('pointerdown', handlePointerDown, { passive: false });
+    window.addEventListener('pointermove', handlePointerMove, { passive: false });
+    window.addEventListener('pointerup', handlePointerUp, { passive: false });
+    window.addEventListener('pointercancel', handlePointerUp, { passive: false });
+
     return () => {
       window.removeEventListener('pointerdown', handlePointerDown);
       window.removeEventListener('pointermove', handlePointerMove);
       window.removeEventListener('pointerup', handlePointerUp);
+      window.removeEventListener('pointercancel', handlePointerUp);
     };
   }, [callback]);
 }

--- a/src/pages/GameScreen.js
+++ b/src/pages/GameScreen.js
@@ -20,6 +20,7 @@ function GameScreen() {
     const canvas = document.getElementById('game-canvas');
     const ctx = canvas.getContext('2d');
     const state = (stateRef.current = createGameState());
+    state.bounds = { width: canvas.width, height: canvas.height };
     let animationId;
     let lastTime = performance.now();
 
@@ -112,16 +113,16 @@ function GameScreen() {
 
   usePointerControls(({ type, x, y }) => {
     if (type === 'move' || type === 'down') {
-      const player = stateRef.current.player;
+      const { player, bounds } = stateRef.current;
       player.x = Math.max(
         0,
-        Math.min(800 - player.width, x - player.width / 2)
+        Math.min(bounds.width - player.width, x - player.width / 2)
       );
       player.y = Math.max(
         0,
-        Math.min(600 - player.height, y - player.height / 2)
+        Math.min(bounds.height - player.height, y - player.height / 2)
       );
-    } else if (type === 'up') {
+    } else if (type === 'up' || type === 'fire') {
       stateRef.current.bullets.push({
         x:
           stateRef.current.player.x +


### PR DESCRIPTION
## Summary
- throttle pointer movement events and track active pointer
- treat extra touches as fire input and ignore their movement
- clamp player position using canvas bounds stored in stateRef

## Testing
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_688eeeff27a0832aacc84d6ff8a70a12