### PR TITLE
Add game logic and settings tests with CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm test -- --watchAll=false

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "react-dom": "^19.1.1",
         "react-redux": "^9.2.0",
         "react-router-dom": "^6.30.1",
-        "react-scripts": "5.0.1",
+        "react-scripts": "^5.0.1",
         "web-vitals": "^2.1.4"
       }
     },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "react-dom": "^19.1.1",
     "react-redux": "^9.2.0",
     "react-router-dom": "^6.30.1",
-    "react-scripts": "5.0.1",
+    "react-scripts": "^5.0.1",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -12,3 +12,13 @@ test('renders main menu title', () => {
   const titleElement = screen.getByText(/Spreadshooter1971/i);
   expect(titleElement).toBeInTheDocument();
 });
+
+test('renders navigation links', () => {
+  render(
+    <Provider store={store}>
+      <App />
+    </Provider>
+  );
+  expect(screen.getByText(/Start Game/i)).toBeInTheDocument();
+  expect(screen.getByText(/Settings/i)).toBeInTheDocument();
+});

--- a/src/pages/Settings.test.js
+++ b/src/pages/Settings.test.js
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import { store } from '../store';
+import Settings from './Settings';
+import { MemoryRouter } from 'react-router-dom';
+
+test('toggles sound option', async () => {
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <Settings />
+      </MemoryRouter>
+    </Provider>
+  );
+  const checkbox = screen.getByRole('checkbox');
+  expect(checkbox).toBeChecked();
+  await userEvent.click(checkbox);
+  expect(checkbox).not.toBeChecked();
+});
+
+test('changes difficulty selection', async () => {
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <Settings />
+      </MemoryRouter>
+    </Provider>
+  );
+  const select = screen.getByRole('combobox');
+  await userEvent.selectOptions(select, 'hard');
+  expect(select).toHaveValue('hard');
+});

--- a/src/utils/gameState.test.js
+++ b/src/utils/gameState.test.js
@@ -1,4 +1,12 @@
 import { createGameState, updateGameState } from './gameState';
+import { store } from '../store';
+import { setDifficulty } from '../store/settingsSlice';
+import { resetGame } from '../store/gameSlice';
+
+beforeEach(() => {
+  store.dispatch(setDifficulty('normal'));
+  store.dispatch(resetGame());
+});
 
 test('updateGameState moves enemies and bullets', () => {
   const state = createGameState();
@@ -9,7 +17,7 @@ test('updateGameState moves enemies and bullets', () => {
   expect(state.bullets[0].y).toBe(18);
 });
 
-test('bullet and enemy collision removes both and increments score', () => {
+test('bullet and enemy collision removes both, creates explosion, and increments score', () => {
   const state = createGameState();
   state.enemies = [{ x: 0, y: 0, width: 10, height: 10, vx: 0, vy: 0 }];
   state.bullets = [{ x: 0, y: 0, width: 10, height: 10, vy: 0 }];
@@ -17,5 +25,22 @@ test('bullet and enemy collision removes both and increments score', () => {
   updateGameState(state, dispatch, 1 / 60);
   expect(state.enemies).toHaveLength(0);
   expect(state.bullets).toHaveLength(0);
+  expect(state.explosions).toHaveLength(1);
   expect(dispatch).toHaveBeenCalled();
+});
+
+test('spawns enemy when spawn timer exceeds interval', () => {
+  const state = createGameState();
+  state.spawnTimer = state.spawnInterval;
+  updateGameState(state, () => {}, 1 / 60);
+  expect(state.enemies).toHaveLength(1);
+});
+
+test('updates spawn interval and timer when difficulty changes', () => {
+  const state = createGameState();
+  state.spawnTimer = 10;
+  store.dispatch(setDifficulty('hard'));
+  updateGameState(state, () => {}, 1 / 60);
+  expect(state.spawnInterval).toBe(40);
+  expect(state.spawnTimer).toBe(1);
 });


### PR DESCRIPTION
## Summary
- restore react-scripts dependency for CRA tests
- add unit tests covering collision, spawning, and settings interactions
- verify App navigation links render
- run tests in GitHub Actions on push/PR

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_688ef0b1b0f0832a9455f09a235049a3