### PR TITLE
Add dynamic canvas and starfield visuals

### DIFF
--- a/src/pages/GameScreen.css
+++ b/src/pages/GameScreen.css
@@ -1,8 +1,11 @@
 .game-screen {
   position: relative;
-  width: 100%;
-  height: 100%;
-  background: #000;
+  width: 100vw;
+  height: 100vh;
+}
+
+#game-canvas {
+  display: block;
 }
 
 .hud {


### PR DESCRIPTION
## Summary
- Resize canvas with window and reinitialize game bounds and stars
- Draw gradient space backdrop with parallax starfield
- Render explosions with radial gradient bursts

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_688f06b10080832ab69ca62f766f9bad