### PR TITLE
Configure BrowserRouter basename for GitHub Pages

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,7 @@ import './App.css';
 
 function App() {
   return (
-    <BrowserRouter>
+    <BrowserRouter basename={process.env.PUBLIC_URL.replace(window.location.origin, '')}>
       <Routes>
         <Route path="/" element={<MainMenu />} />
         <Route path="/game" element={<GameScreen />} />


### PR DESCRIPTION
## Summary
- ensure BrowserRouter uses `process.env.PUBLIC_URL` as basename for proper routing on deployment

## Testing
- `npm test -- --watchAll=false`
- `npm run build`
- `npm run deploy` *(fails: Failed to get remote.origin.url)*

------
https://chatgpt.com/codex/tasks/task_e_688f15cd19e0832ab97c79b8edf8d24b