### PR TITLE
memoize pointer handlers

### DIFF
--- a/src/hooks/usePointerControls.js
+++ b/src/hooks/usePointerControls.js
@@ -1,6 +1,12 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 export function usePointerControls(callback) {
+  const callbackRef = useRef(callback);
+
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
+
   useEffect(() => {
     let activePointerId = null;
     let lastMove = 0;
@@ -12,10 +18,10 @@ export function usePointerControls(callback) {
 
       if (activePointerId === null) {
         activePointerId = pointerId;
-        callback({ type: 'down', x, y, pointerType });
+        callbackRef.current({ type: 'down', x, y, pointerType });
       } else {
         // Secondary touches trigger a fire event
-        callback({ type: 'fire', x, y, pointerType });
+        callbackRef.current({ type: 'fire', x, y, pointerType });
       }
     };
 
@@ -29,7 +35,7 @@ export function usePointerControls(callback) {
       if (now - lastMove < THROTTLE_MS) return;
       lastMove = now;
 
-      callback({ type: 'move', x, y, pointerType });
+      callbackRef.current({ type: 'move', x, y, pointerType });
     };
 
     const handlePointerUp = (event) => {
@@ -38,10 +44,10 @@ export function usePointerControls(callback) {
 
       if (pointerId === activePointerId) {
         activePointerId = null;
-        callback({ type: 'up', x, y, pointerType });
+        callbackRef.current({ type: 'up', x, y, pointerType });
       } else {
         // Treat pointer releases from other touches as fire events
-        callback({ type: 'fire', x, y, pointerType });
+        callbackRef.current({ type: 'fire', x, y, pointerType });
       }
     };
 
@@ -56,5 +62,5 @@ export function usePointerControls(callback) {
       window.removeEventListener('pointerup', handlePointerUp);
       window.removeEventListener('pointercancel', handlePointerUp);
     };
-  }, [callback]);
+  }, []);
 }

--- a/src/pages/GameScreen.js
+++ b/src/pages/GameScreen.js
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { resetGame } from '../store/gameSlice';
 import { usePointerControls } from '../hooks/usePointerControls';
@@ -173,34 +173,39 @@ function GameScreen() {
     }
   }, [soundOn]);
 
-  usePointerControls(({ type, x, y }) => {
-    if (type === 'move' || type === 'down') {
-      const { player, bounds } = stateRef.current;
-      player.x = Math.max(
-        0,
-        Math.min(bounds.width - player.width, x - player.width / 2)
-      );
-      player.y = Math.max(
-        0,
-        Math.min(bounds.height - player.height, y - player.height / 2)
-      );
-    } else if (type === 'up' || type === 'fire') {
-      stateRef.current.bullets.push({
-        x:
-          stateRef.current.player.x +
-          stateRef.current.player.width / 2 -
-          4,
-        y: stateRef.current.player.y,
-        width: 8,
-        height: 16,
-        vy: 6,
-      });
-      if (soundOn && soundsRef.current.shoot) {
-        const pew = soundsRef.current.shoot.cloneNode();
-        pew.play();
+  const handlePointer = useCallback(
+    ({ type, x, y }) => {
+      if (type === 'move' || type === 'down') {
+        const { player, bounds } = stateRef.current;
+        player.x = Math.max(
+          0,
+          Math.min(bounds.width - player.width, x - player.width / 2)
+        );
+        player.y = Math.max(
+          0,
+          Math.min(bounds.height - player.height, y - player.height / 2)
+        );
+      } else if (type === 'up' || type === 'fire') {
+        stateRef.current.bullets.push({
+          x:
+            stateRef.current.player.x +
+            stateRef.current.player.width / 2 -
+            4,
+          y: stateRef.current.player.y,
+          width: 8,
+          height: 16,
+          vy: 6,
+        });
+        if (soundOn && soundsRef.current.shoot) {
+          const pew = soundsRef.current.shoot.cloneNode();
+          pew.play();
+        }
       }
-    }
-  });
+    },
+    [soundOn]
+  );
+
+  usePointerControls(handlePointer);
 
   return (
     <div className="game-screen" style={{ touchAction: 'none' }}>


### PR DESCRIPTION
## Summary
- preserve latest pointer callback in a ref to avoid reattaching listeners
- memoize pointer handler on GameScreen with useCallback

## Testing
- `npm test -- --watchAll=false --silent`


------
https://chatgpt.com/codex/tasks/task_e_688f2338750c832a8d6e8b619f18c4ee