### PR TITLE
Add wingman, powerups, HUD, and updated game state logic

### DIFF
--- a/src/pages/GameScreen.css
+++ b/src/pages/GameScreen.css
@@ -14,3 +14,38 @@
   left: 10px;
   color: white;
 }
+
+.hud-secondary {
+  top: 34px;
+}
+
+.hud-level {
+  top: 58px;
+}
+
+.hud-wingman {
+  top: 86px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.wingman-bar-shell {
+  width: 150px;
+  height: 12px;
+  border: 1px solid #fff;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.wingman-bar-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #2fd65d, #7eff99);
+}
+
+.hud-invincible {
+  top: 10px;
+  left: auto;
+  right: 10px;
+  color: #ffe347;
+  font-weight: 700;
+}

--- a/src/pages/GameScreen.js
+++ b/src/pages/GameScreen.js
@@ -10,6 +10,7 @@ import './GameScreen.css';
 function GameScreen() {
   const dispatch = useDispatch();
   const lives = useSelector((state) => state.game.lives);
+  const score = useSelector((state) => state.game.score);
   const soundOn = useSelector((state) => state.settings.soundOn);
   const stateRef = useRef(createGameState());
   const soundsRef = useRef({});
@@ -139,6 +140,28 @@ function GameScreen() {
           );
         });
 
+        if (state.wingman.active) {
+          ctx.fillStyle = '#55d6ff';
+          ctx.fillRect(
+            state.wingman.x,
+            state.wingman.y,
+            state.wingman.width,
+            state.wingman.height
+          );
+        }
+
+        state.powerups.forEach((powerup) => {
+          if (powerup.type === 'bomb') ctx.fillStyle = '#ff7a00';
+          else if (powerup.type === 'life') ctx.fillStyle = '#2fd65d';
+          else ctx.fillStyle = '#ffe347';
+          ctx.fillRect(powerup.x, powerup.y, powerup.width, powerup.height);
+          ctx.fillStyle = '#111';
+          ctx.font = 'bold 12px sans-serif';
+          const glyph =
+            powerup.type === 'bomb' ? 'B' : powerup.type === 'life' ? '+' : 'I';
+          ctx.fillText(glyph, powerup.x + 7, powerup.y + 16);
+        });
+
         state.explosions.forEach((explosion) => {
           const progress = explosion.frame / 15;
           const radius = (explosion.width / 2) * progress;
@@ -209,6 +232,15 @@ function GameScreen() {
           height: 16,
           vy: 6,
         });
+        if (stateRef.current.wingman.active) {
+          stateRef.current.bullets.push({
+            x: stateRef.current.wingman.x + stateRef.current.wingman.width / 2 - 3,
+            y: stateRef.current.wingman.y,
+            width: 6,
+            height: 14,
+            vy: 7,
+          });
+        }
         if (soundOn && soundsRef.current.shoot) {
           const pew = soundsRef.current.shoot.cloneNode();
           pew.play();
@@ -224,6 +256,22 @@ function GameScreen() {
     <div className="game-screen" style={{ touchAction: 'none' }}>
       <canvas id="game-canvas" />
       <div className="hud">Lives: {lives}</div>
+      <div className="hud hud-secondary">Score: {score}</div>
+      <div className="hud hud-level">Level: {stateRef.current.level}</div>
+      <div className="hud hud-wingman">
+        Wingman HP
+        <div className="wingman-bar-shell">
+          <div
+            className="wingman-bar-fill"
+            style={{
+              width: `${(stateRef.current.wingman.hp / stateRef.current.wingman.maxHp) * 100}%`,
+            }}
+          />
+        </div>
+      </div>
+      {performance.now() < stateRef.current.player.invincibleUntil && (
+        <div className="hud hud-invincible">INVINCIBLE</div>
+      )}
       {!isReady && !loadError && <div className="hud">Loading assets…</div>}
       {loadError && <div className="hud">Asset load failed: {loadError}</div>}
     </div>

--- a/src/store/gameSlice.js
+++ b/src/store/gameSlice.js
@@ -21,6 +21,10 @@ const gameSlice = createSlice({
       if (state.lives > 0) state.lives -= 1;
       if (state.lives <= 0) state.isGameOver = true;
     },
+    gainLife: (state, action) => {
+      const amount = action.payload ?? 1;
+      state.lives += amount;
+    },
     resetGame: (state) => {
       state.score = 0;
       state.lives = initialState.lives;
@@ -29,5 +33,5 @@ const gameSlice = createSlice({
   },
 });
 
-export const { incrementScore, playerDamaged, resetGame } = gameSlice.actions;
+export const { incrementScore, playerDamaged, gainLife, resetGame } = gameSlice.actions;
 export default gameSlice.reducer;

--- a/src/utils/gameState.js
+++ b/src/utils/gameState.js
@@ -1,6 +1,12 @@
-import { incrementScore } from '../store/gameSlice';
+import { gainLife, incrementScore, playerDamaged } from '../store/gameSlice';
 import { store } from '../store';
 import { DIFFICULTY_CONFIG } from '../store/settingsSlice';
+
+const POWERUP_TYPES = {
+  BOMB: 'bomb',
+  LIFE: 'life',
+  INVINCIBLE: 'invincible',
+};
 
 function createEnemy(difficulty, boundsWidth = 800) {
   const config = DIFFICULTY_CONFIG[difficulty];
@@ -31,16 +37,41 @@ function createEnemy(difficulty, boundsWidth = 800) {
   }
 }
 
+function overlaps(a, b) {
+  return (
+    a.x < b.x + b.width &&
+    a.x + a.width > b.x &&
+    a.y < b.y + b.height &&
+    a.y + a.height > b.y
+  );
+}
+
+function createRandomPowerup(level, difficulty, x, y) {
+  const difficultyMultiplier = difficulty === 'hard' ? 1.3 : difficulty === 'easy' ? 0.8 : 1;
+  const weightedRoll = Math.random() * (1 + level * 0.05) * difficultyMultiplier;
+
+  if (weightedRoll < 0.5) return null;
+  if (weightedRoll < 1.1) return POWERUP_TYPES.BOMB;
+  if (weightedRoll < 1.7) return POWERUP_TYPES.INVINCIBLE;
+  return POWERUP_TYPES.LIFE;
+}
+
 export function createGameState(bounds = { width: 800, height: 600 }) {
   const difficulty = store.getState().settings.difficulty;
   return {
-    player: { x: 400, y: 550, width: 48, height: 48, vx: 0, vy: 0 },
+    player: { x: 400, y: 550, width: 48, height: 48, vx: 0, vy: 0, invincibleUntil: 0 },
+    wingman: { x: 450, y: 560, width: 36, height: 36, hp: 100, maxHp: 100, active: true },
     enemies: [],
     bullets: [],
     explosions: [],
+    powerups: [],
     spawnTimer: 0,
     spawnInterval: DIFFICULTY_CONFIG[difficulty].spawnInterval,
     level: 1,
+    levelDropsMultiplier: 1,
+    damageCooldown: 0,
+    dropChance: 0.12,
+    elapsed: 0,
     difficulty,
     bounds,
   };
@@ -49,6 +80,8 @@ export function createGameState(bounds = { width: 800, height: 600 }) {
 export function updateGameState(state, dispatch, delta = 1 / 60) {
   const difficulty = store.getState().settings.difficulty;
   const deltaFrames = delta * 60;
+  const now = performance.now();
+  state.elapsed += delta;
 
   // If difficulty changed mid-game, update spawn interval accordingly
   if (difficulty !== state.difficulty) {
@@ -65,6 +98,18 @@ export function updateGameState(state, dispatch, delta = 1 / 60) {
   }
 
   const boundsWidth = state.bounds?.width ?? 800;
+  const boundsHeight = state.bounds?.height ?? 600;
+
+  state.damageCooldown = Math.max(0, state.damageCooldown - delta);
+  state.wingman.x = Math.min(
+    boundsWidth - state.wingman.width,
+    state.player.x + state.player.width + 8
+  );
+  state.wingman.y = Math.min(
+    boundsHeight - state.wingman.height,
+    state.player.y + Math.max(0, state.player.height - state.wingman.height)
+  );
+  state.wingman.active = state.wingman.hp > 0;
 
   state.enemies.forEach((enemy) => {
     enemy.x += enemy.vx * deltaFrames;
@@ -79,18 +124,16 @@ export function updateGameState(state, dispatch, delta = 1 / 60) {
     bullet.y -= bullet.vy * deltaFrames;
   });
   state.bullets = state.bullets.filter((bullet) => bullet.y + bullet.height > 0);
+  state.powerups.forEach((powerup) => {
+    powerup.y += powerup.vy * deltaFrames;
+  });
+  state.powerups = state.powerups.filter((powerup) => powerup.y < boundsHeight + powerup.height);
 
   for (let i = state.bullets.length - 1; i >= 0; i--) {
     const bullet = state.bullets[i];
     for (let j = state.enemies.length - 1; j >= 0; j--) {
       const enemy = state.enemies[j];
-      const overlap =
-        bullet.x < enemy.x + enemy.width &&
-        bullet.x + bullet.width > enemy.x &&
-        bullet.y < enemy.y + enemy.height &&
-        bullet.y + bullet.height > enemy.y;
-
-      if (overlap) {
+      if (overlaps(bullet, enemy)) {
         state.bullets.splice(i, 1);
         state.enemies.splice(j, 1);
         state.explosions.push({
@@ -101,8 +144,82 @@ export function updateGameState(state, dispatch, delta = 1 / 60) {
           frame: 0,
         });
         dispatch && dispatch(incrementScore());
+        const dropRoll = Math.random();
+        if (dropRoll < state.dropChance * state.levelDropsMultiplier) {
+          const powerupType = createRandomPowerup(state.level, difficulty, enemy.x, enemy.y);
+          if (powerupType) {
+            state.powerups.push({
+              type: powerupType,
+              x: enemy.x + enemy.width / 2 - 12,
+              y: enemy.y,
+              width: 24,
+              height: 24,
+              vy: 1.5,
+            });
+          }
+        }
         break;
       }
+    }
+  }
+
+  for (let i = state.enemies.length - 1; i >= 0; i--) {
+    const enemy = state.enemies[i];
+    const hitPlayer = overlaps(enemy, state.player);
+    const hitWingman = state.wingman.active && overlaps(enemy, state.wingman);
+
+    if (hitWingman) {
+      state.wingman.hp = Math.max(0, state.wingman.hp - 20);
+      state.enemies.splice(i, 1);
+      state.explosions.push({
+        x: enemy.x,
+        y: enemy.y,
+        width: enemy.width,
+        height: enemy.height,
+        frame: 0,
+      });
+      continue;
+    }
+
+    if (hitPlayer) {
+      state.enemies.splice(i, 1);
+      state.explosions.push({
+        x: enemy.x,
+        y: enemy.y,
+        width: enemy.width,
+        height: enemy.height,
+        frame: 0,
+      });
+      const isInvincible = now < state.player.invincibleUntil;
+      if (!isInvincible && state.damageCooldown <= 0) {
+        dispatch && dispatch(playerDamaged());
+        state.damageCooldown = 0.8;
+      }
+    }
+  }
+
+  for (let i = state.powerups.length - 1; i >= 0; i--) {
+    const powerup = state.powerups[i];
+    if (!overlaps(powerup, state.player)) continue;
+    state.powerups.splice(i, 1);
+    if (powerup.type === POWERUP_TYPES.BOMB) {
+      const destroyed = state.enemies.length;
+      state.enemies = [];
+      if (destroyed > 0 && dispatch) {
+        dispatch(incrementScore(destroyed));
+      }
+      state.explosions.push({
+        x: 0,
+        y: 0,
+        width: boundsWidth,
+        height: boundsHeight,
+        frame: 0,
+      });
+    } else if (powerup.type === POWERUP_TYPES.LIFE) {
+      dispatch && dispatch(gainLife());
+      state.wingman.hp = Math.min(state.wingman.maxHp, state.wingman.hp + 25);
+    } else if (powerup.type === POWERUP_TYPES.INVINCIBLE) {
+      state.player.invincibleUntil = now + 8000;
     }
   }
 
@@ -111,6 +228,8 @@ export function updateGameState(state, dispatch, delta = 1 / 60) {
   if (newLevel > state.level) {
     state.level = newLevel;
     state.spawnInterval = Math.max(10, state.spawnInterval - 5);
+    state.levelDropsMultiplier = Math.min(2.5, 1 + state.level * 0.12);
+    state.dropChance = Math.min(0.5, 0.12 + state.level * 0.02);
     state.spawnTimer = 0;
   }
 


### PR DESCRIPTION
### Motivation
- Introduce a supporting wingman, collectible powerups, and on-screen HUD to increase gameplay depth and give players visual feedback. 
- Provide persistent game-level and drop mechanics so progression affects spawn and powerup rates. 

### Description
- UI: display `Score`, `Level`, wingman HP bar, and an `INVINCIBLE` indicator in `GameScreen.js` and added corresponding styles in `GameScreen.css`.
- Rendering/controls: draw a wingman and powerups on the canvas, and fire secondary bullets from the wingman when active in `GameScreen.js` render and input handling.
- Redux: added a `gainLife` action to `gameSlice.js` and exported it with other game actions.
- Game state: extended `createGameState` to include `wingman`, `powerups`, timing/cooldown fields, and other metadata; implemented `updateGameState` changes to handle spawning, bullet/enemy collisions, wingman collisions, powerup drops and pickups, bomb/life/invincibility powerup effects, damage cooldown, level scaling, and drop-rate multipliers in `utils/gameState.js`.
- Utilities: added helper functions for overlap detection and randomized powerup creation to drive drop logic.

### Testing
- Ran the project test suite with `npm test` and the linter with `npm run lint`; existing automated tests and lint checks completed successfully with no failures.
- No new automated tests were added for the new gameplay features in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb1326cfec832abf7a5f1f2889aaec)