### PR TITLE
Harden score and life reducers against adversarial payloads

### DIFF
--- a/src/store/gameSlice.js
+++ b/src/store/gameSlice.js
@@ -12,7 +12,10 @@ const gameSlice = createSlice({
   initialState,
   reducers: {
     incrementScore: (state, action) => {
-      state.score += action.payload ?? 1;
+      const rawAmount = action.payload ?? 1;
+      const amount =
+        Number.isFinite(rawAmount) && rawAmount > 0 ? Math.floor(rawAmount) : 0;
+      state.score += amount;
       if (state.score > state.highScore) {
         state.highScore = state.score;
       }
@@ -23,7 +26,9 @@ const gameSlice = createSlice({
     },
     gainLife: (state, action) => {
       const amount = action.payload ?? 1;
-      state.lives += amount;
+      const normalizedAmount =
+        Number.isFinite(amount) && amount > 0 ? Math.floor(amount) : 0;
+      state.lives += normalizedAmount;
     },
     resetGame: (state) => {
       state.score = 0;

--- a/src/store/gameSlice.test.js
+++ b/src/store/gameSlice.test.js
@@ -1,0 +1,35 @@
+import reducer, { gainLife, incrementScore } from './gameSlice';
+
+describe('gameSlice adversarial payload hardening', () => {
+  test('incrementScore ignores non-finite and non-positive payloads', () => {
+    let state = reducer(undefined, { type: '@@INIT' });
+
+    state = reducer(state, incrementScore(-5));
+    state = reducer(state, incrementScore(Number.NaN));
+    state = reducer(state, incrementScore(Number.POSITIVE_INFINITY));
+
+    expect(state.score).toBe(0);
+    expect(state.highScore).toBe(0);
+  });
+
+  test('gainLife ignores non-finite and non-positive payloads', () => {
+    let state = reducer(undefined, { type: '@@INIT' });
+
+    state = reducer(state, gainLife(-2));
+    state = reducer(state, gainLife(Number.NaN));
+    state = reducer(state, gainLife(Number.POSITIVE_INFINITY));
+
+    expect(state.lives).toBe(3);
+  });
+
+  test('normal positive payloads are applied with integer normalization', () => {
+    let state = reducer(undefined, { type: '@@INIT' });
+
+    state = reducer(state, incrementScore(2.9));
+    state = reducer(state, gainLife(1.8));
+
+    expect(state.score).toBe(2);
+    expect(state.highScore).toBe(2);
+    expect(state.lives).toBe(4);
+  });
+});

--- a/src/utils/gameState.js
+++ b/src/utils/gameState.js
@@ -224,7 +224,8 @@ export function updateGameState(state, dispatch, delta = 1 / 60) {
   }
 
   const score = store.getState().game.score;
-  const newLevel = Math.floor(score / 10) + 1;
+  const safeScore = Number.isFinite(score) && score > 0 ? score : 0;
+  const newLevel = Math.floor(safeScore / 10) + 1;
   if (newLevel > state.level) {
     state.level = newLevel;
     state.spawnInterval = Math.max(10, state.spawnInterval - 5);


### PR DESCRIPTION
### Motivation
- Prevent malformed or adversarial action payloads (negative numbers, `NaN`, `Infinity`, non-integers) from corrupting persistent game state like `score`, `highScore`, and `lives`. 
- Make level progression computation resilient to tampered `score` values coming from the store. 
- Add regression tests to lock down expected behavior for both invalid and fractional payloads.

### Description
- Sanitize `incrementScore` in `src/store/gameSlice.js` so it accepts only finite, positive values and normalizes decimals with `Math.floor` before applying changes to `score` and `highScore`. 
- Apply the same finite/positive integer normalization to `gainLife` in `src/store/gameSlice.js` so `lives` cannot be altered by invalid payloads. 
- Guard level calculation in `src/utils/gameState.js` by deriving `newLevel` from a validated `safeScore` (finite and non-negative) to avoid unstable level math. 
- Add adversarial regression tests in `src/store/gameSlice.test.js` covering negative, `NaN`, `Infinity`, and decimal payload cases to ensure normalization and rejection behavior.

### Testing
- Ran the test suite with `npm test -- --watchAll=false` and all tests passed. 
- Test summary: 4 test suites passed, 13 tests passed, and the new `src/store/gameSlice.test.js` exercises the hardened reducers and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce8a0c70b4832a9564349fcf43c46d)